### PR TITLE
fix: Slot nodes are not cleaned up after component destruction.

### DIFF
--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -51,6 +51,9 @@ export default {
     this.maybeMove();
   },
   beforeDestroy() {
+    // Fix nodes reference
+    this.nodes = this.getComponentChildrenNode();
+
     // Move back
     this.disable();
 
@@ -76,7 +79,7 @@ export default {
       this.waiting = false;
 
       this.parent = document.querySelector(this.to);
-      
+
       if (!this.parent) {
         this.disable();
 
@@ -147,7 +150,7 @@ export default {
         if (childChangeRecord) {
           // Remove old nodes before update position.
           this.nodes.forEach((node) => node.parentNode && node.parentNode.removeChild(node));
-          this.nodes = this.$vnode.componentOptions.children.map(i => i.elm).filter(i => i);
+          this.nodes = this.getComponentChildrenNode();
           this.maybeMove();
         }
       });
@@ -168,6 +171,11 @@ export default {
         this.childObserver.disconnect();
         this.childObserver = null;
       }
+    },
+    getComponentChildrenNode() {
+      return this.$vnode.componentOptions.children
+        .map((i) => i.elm)
+        .filter((i) => i);
     },
   },
 };

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -145,6 +145,7 @@ export default {
       this.childObserver = new MutationObserver(mutations => {
         const childChangeRecord = mutations.find(i => i.target === this.$el);
         if (childChangeRecord) {
+          this.nodes = this.$vnode.componentOptions.children.map(i => i.elm);
           this.maybeMove();
         }
       });

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -76,8 +76,6 @@ export default {
       this.waiting = false;
 
       this.parent = document.querySelector(this.to);
-      // Remove old nodes before update position.
-      this.nodes.forEach((node) => node.parentNode && node.parentNode.removeChild(node));
       
       if (!this.parent) {
         this.disable();
@@ -147,6 +145,8 @@ export default {
       this.childObserver = new MutationObserver(mutations => {
         const childChangeRecord = mutations.find(i => i.target === this.$el);
         if (childChangeRecord) {
+          // Remove old nodes before update position.
+          this.nodes.forEach((node) => node.parentNode && node.parentNode.removeChild(node));
           this.nodes = this.$vnode.componentOptions.children.map(i => i.elm).filter(i => i);
           this.maybeMove();
         }

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -145,7 +145,7 @@ export default {
       this.childObserver = new MutationObserver(mutations => {
         const childChangeRecord = mutations.find(i => i.target === this.$el);
         if (childChangeRecord) {
-          this.nodes = this.$vnode.componentOptions.children.map(i => i.elm);
+          this.nodes = this.$vnode.componentOptions.children.map(i => i.elm).filter(i => i);
           this.maybeMove();
         }
       });

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -32,6 +32,10 @@ export default {
     disabled(value) {
       if (value) {
         this.disable();
+        // Ensure all event done.
+        this.$nextTick(() => {
+          this.teardownObserver();
+        });
         this.teardownObserver();
       } else {
         this.bootObserver();

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -76,7 +76,9 @@ export default {
       this.waiting = false;
 
       this.parent = document.querySelector(this.to);
-
+      // Remove old nodes before update position.
+      this.nodes.forEach((node) => node.parentNode.removeChild(node));
+      
       if (!this.parent) {
         this.disable();
 

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -77,7 +77,7 @@ export default {
 
       this.parent = document.querySelector(this.to);
       // Remove old nodes before update position.
-      this.nodes.forEach((node) => node.parentNode.removeChild(node));
+      this.nodes.forEach((node) => node.parentNode && node.parentNode.removeChild(node));
       
       if (!this.parent) {
         this.disable();

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -36,7 +36,6 @@ export default {
         this.$nextTick(() => {
           this.teardownObserver();
         });
-        this.teardownObserver();
       } else {
         this.bootObserver();
         this.move();

--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -145,7 +145,6 @@ export default {
       this.childObserver = new MutationObserver(mutations => {
         const childChangeRecord = mutations.find(i => i.target === this.$el);
         if (childChangeRecord) {
-          this.nodes = Array.from(this.$el.childNodes);
           this.maybeMove();
         }
       });


### PR DESCRIPTION
My mistake, this line of code caused the nodes to not synchronize destruction after the teleport component was destroyed. It still works fine after removing it.
fix #5 
fix #6