### PR TITLE
Allow passing html element

### DIFF
--- a/src/Teleport.vue
+++ b/src/Teleport.vue
@@ -82,7 +82,7 @@ export default {
     move() {
       this.waiting = false;
 
-      const parent = document.querySelector(this.to);
+      const parent = this.to instanceof HTMLElement ? this.to : document.querySelector(this.to);
 
       if (!parent) {
         this.disable();


### PR DESCRIPTION
Allow passing an existing HTMLElement as the `to` prop. This also aligns with the [vue docs](https://vuejs.org/api/built-in-components.html#teleport).