### PR TITLE
Release 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue2-teleport",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue2-teleport",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "devDependencies": {
         "@rollup/plugin-buble": "^0.21.3",
         "@rollup/plugin-commonjs": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-teleport",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Mechazawa/vue2-teleport.git"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "browser": {
     "./sfc": "src/teleport.vue"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "all": "npm run lint && npm run clean && npm run build",
     "build": "npm run build:umd & npm run build:es & npm run build:unpkg",


### PR DESCRIPTION
Release v1.2.0 (published to npm).

- `to` prop accepts `HTMLElement` in addition to a selector string (#11, #16)
- CI fixed (deprecated actions bumped, eslint config inlined)
- Add a `files` whitelist so only dist/ + src/ are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)