### PR TITLE
Add license field (CC0-1.0) to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vue2-teleport",
   "version": "1.2.0",
+  "license": "CC0-1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Mechazawa/vue2-teleport.git"


### PR DESCRIPTION
fixes #14

The repository ships a `LICENSE` file containing the **CC0 1.0 Universal** public-domain dedication (SPDX identifier: `CC0-1.0`), but `package.json` had no `"license"` field. This adds the field so the package metadata matches the bundled license.

The field was placed immediately after `"version"`, with no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)