### PR TITLE
Stop leaking dev paths and </script> into dist bundles

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -13,6 +13,7 @@ export default {
         vue({
             css: true, // Dynamically inject css as a <style> tag
             compileTemplate: true, // Explicitly convert template to render function
+            needMap: false, // Don't embed block sourcemaps (leaks dev paths + literal </script> into dist)
         }),
         buble(), // Transpile to ES5
     ],


### PR DESCRIPTION
fixes #9
fixes #13

## Root cause

Both issues come from the same place. `rollup-plugin-vue` embeds the scoped-`<style>` block's sourcemap inside the generated `__vue_inject_styles__` call in each bundle. That embedded map carries two things:

- **`sources`**: the absolute dev-machine path (e.g. `/home/<user>/.../src/Teleport.vue`), which leaks the build machine's directory structure (#13).
- **`sourcesContent`**: the whole `.vue` source, including the literal `</script>` from its `<script>` block. When a consumer inlines the bundle inside an HTML `<script>` tag, that literal `</script>` closes the tag early and breaks the page (#9).

## Fix

Pass `needMap: false` to the `vue({ ... })` plugin options in `build/rollup.config.js`. `rollup-plugin-vue@5` forwards `needMap` to the SFC compiler, which stops emitting the block sourcemaps. Both leaks go away and the scoped CSS and component logic stay intact.

## Verification

After rebuilding all three formats (`teleport.umd.js`, `teleport.esm.js`, `teleport.min.js`):

Leaks gone (no matches in `dist/`):
- `grep -r "/home/" dist/`
- `grep -rF "</script>" dist/`
- `grep -r "sourcesContent" dist/`

Functionality preserved (still present in all three bundles):
- `grep -rl "visibility: hidden" dist/` (scoped CSS still injected)
- `grep -rl "MutationObserver" dist/` (component logic still bundled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
