### PR TITLE
Publish to npm on tag push (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,4 +28,3 @@ jobs:
             package.json
             package-lock.json
             src
-            build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+# Publishes the package to npm whenever a version tag (v*) is pushed.
+#
+# Authentication uses npm OIDC "Trusted Publishing" (configured on npmjs.com
+# for this repo + this workflow file), so no NPM_TOKEN secret is required.
+# This needs `id-token: write` permission and npm >= 11.5.1; provenance is
+# generated automatically.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "tag=$TAG package.json=$PKG"
+          test "$TAG" = "$PKG" || { echo "::error::Tag v$TAG does not match package.json version $PKG"; exit 1; }
+      # `npm publish` runs the prepublishOnly script (lint + clean + build),
+      # so the freshly built dist/ is what gets packed and published.
+      - name: Publish to npm
+        run: npm publish --access public


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` so pushing a `v*` tag publishes the package to npm.

- **Auth:** npm OIDC **Trusted Publishing**, already configured on npmjs.com for `Mechazawa/vue2-teleport` and the `publish.yml` workflow. No `NPM_TOKEN` secret required. It needs `id-token: write` and npm >= 11.5.1 (the job upgrades npm), and emits build **provenance** automatically.
- **Safety:** a step asserts the pushed tag (`v1.2.1`) matches the `package.json` version before publishing.
- `npm publish` runs `prepublishOnly` (lint, clean, build), so the freshly built, leak-free `dist/` is what gets packed.

Also removes the stale `build` entry from the CI artifact-upload paths. The rollup config moved to the project root in #20, so `build/` no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
